### PR TITLE
test: verify Vercel Node 24 runtime

### DIFF
--- a/src/pages/api/runtime-version.json.ts
+++ b/src/pages/api/runtime-version.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const GET: APIRoute = () =>
+  new Response(JSON.stringify({ node: process.version }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });


### PR DESCRIPTION
Temporary preview-only endpoint for deployment runtime verification. This PR will be closed without merging and the branch deleted after `/api/runtime-version.json` returns `v24.x` evidence.